### PR TITLE
Add FaceUnlock (FaceSense) project for face unlock (A16)

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -21,4 +21,7 @@
     <project path="vendor/gapps" name="MindTheGapps/vendor_gapps" remote="git-lab" revision="baklava" />
 
     <project path="hardware/oplus" name="LineageOS/android_hardware_oplus" remote="git-hub" revision="lineage-23.2" />
+
+    <!-- FaceSense face unlock: app + vendor.aospa.biometrics.face AIDL + Megvii engine + overlay/permissions -->
+    <project path="packages/apps/FaceUnlock" name="Evolution-X/packages_apps_FaceUnlock" remote="git-hub" revision="bka" />
 </manifest>


### PR DESCRIPTION
## What

Adds the `Evolution-X/packages_apps_FaceUnlock` project (branch `bka`, Android 16) to the manifest, providing everything FaceSense face unlock needs (no separate vendor HAL binary required):
- the `co.aospa.sense` (FaceUnlock) privileged app
- the `vendor.aospa.biometrics.face` AIDL interface
- the Megvii face engine prebuilts (arm64)
- the settings overlay + permissions

## Why

The lineage-23.0 manifest carried this project but it was not brought over to the 23.2 line, so face unlock disappeared. This restores it for Android 16 QPR2.

## Pairs with

Companion framework PR in MisterZtr/LineageOS_gsi (branch `facesense-23.2`): https://github.com/MisterZtr/LineageOS_gsi/pull/102 Both are needed together.

## Verified

Built `lineage_arm64_bgN4-bp4a-userdebug` and flashed on Lenovo Y700 (TB-9707F, SD870). `dumpsys face` reports `provider: SenseProvider, sensorId 1008` with an enrolled face and a successful authentication (accept) logged; `ro.face.sense_service=true` and `feature:android.hardware.biometrics.face` are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)